### PR TITLE
Datum::Transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,58 @@ Executing the test:
 5 runs, 15 assertions, 0 failures, 0 errors, 0 skips
 ```
 
+#### Transactional Testing with Scenarios
+##### New in version 4.3.0
+
+Datum out of the box is built to support Rails' transactional tests and fixtures. One thing,
+you may notice though, is that when using scenarios with lots of data,
+loading scenario data for each test case can become very time consuming.
+When utilizing `data_test`s with large scenarios this can cause you test suite run time to balloon.
+
+To improve this there's the `Datum::Transactions` module. This adds a method, `load_scenarios`,
+which can be used in your test class to a set of scenarios once for each test case in the class.
+This is acheived by utilizing Database Cleaner and Mintest Hooks. Rails' default transactional
+fixtures are disabled and new transactions are created around the test class and each test case.
+
+
+Gemfile:
+``` ruby
+gem 'database_cleaner'
+```
+
+test_helper.rb:
+```ruby
+require 'datum/transactions'
+
+class ActiveSupport::TestCase
+  include ::Datum::Transactions
+end
+
+class MyClassTest < ActiveSupport::TestCase
+
+  def load_scenarios
+    process_scenario 'my_scenario'
+  end
+end
+```
+
+##### Disabling for Specific Tests
+
+```ruby
+DatabaseCleaner.strategy = :truncation
+
+class ActionDispatch::IntegrationTest
+  self.datum_transactions = false
+end
+```
+
+##### Gotchas
+
+In order to correctly setup instance state after each test case run instance
+state is snapshotted after load_scenarios is processed and Marshaled. This limits the
+type of objects that can be processed in these scenarios. These scenarios can still be
+processed in a setup method or test case however.
+
 ### Real-World Examples (Not Finished)
 A Model Test to verify addresses from different countries:
 

--- a/datum.gemspec
+++ b/datum.gemspec
@@ -2,8 +2,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:
 require "datum/version"
-# s.add_development_dependency "pg"
-# s.add_dependency "pg"
+
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "datum"
@@ -17,5 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*","MIT-LICENSE","Rakefile","README.md"]
 
-  s.add_development_dependency "minitest", "~> 5.0"
+  s.add_dependency "minitest"
+  s.add_dependency 'minitest-hooks'
+  s.add_development_dependency 'rails'
+  s.add_development_dependency 'database_cleaner'
 end

--- a/lib/datum/transactions.rb
+++ b/lib/datum/transactions.rb
@@ -1,0 +1,62 @@
+require 'database_cleaner'
+
+DatabaseCleaner.strategy = :transaction
+
+module Datum
+  module Transactions
+
+    def self.included(klass)
+      klass.class_eval do
+        class_attribute :datum_transactions
+        self.datum_transactions = true
+      end
+      klass.use_transactional_fixtures = false
+    end
+
+    def load_scenarios
+    end
+
+    def around_all
+      return super unless self.class.datum_transactions
+
+      DatabaseCleaner.cleaning do
+        record_ivars do
+          load_scenarios
+        end
+        super
+      end
+    end
+
+    def around
+      return super unless self.class.datum_transactions
+
+      restore_ivars
+      DatabaseCleaner.cleaning do
+        super
+      end
+    end
+
+    def record_ivars
+      pre = instance_variables
+      yield
+      post = instance_variables
+      serialize_ivars(post - pre)
+    end
+
+    def serialize_ivars(ivars_to_serialize)
+      ivar_hsh = {}
+      ivars_to_serialize.each do |ivar_name|
+        value = instance_variable_get(ivar_name)
+        ivar_hsh[ivar_name] = value
+      end
+      @_serialized_ivars = Marshal.dump(ivar_hsh)
+    end
+
+    def restore_ivars
+      ivar_hsh = Marshal.load(@_serialized_ivars)
+      ivar_hsh.each do |ivar_name, value|
+        instance_variable_set(ivar_name, value)
+      end
+    end
+  end
+end

--- a/lib/datum/version.rb
+++ b/lib/datum/version.rb
@@ -1,6 +1,6 @@
 module Datum
   # @!visibility private
-  VERSION = "4.2.0"
+  VERSION = "4.3.0"
 end
 
 
@@ -24,3 +24,5 @@ end
 ## Removing files.
 ## 4.2.0
 ## Support added for gems.
+## 4.3.0
+## Add load_scenarios and both test and test class level transactions

--- a/lib/support/test.rb
+++ b/lib/support/test.rb
@@ -1,6 +1,7 @@
 require "datum/helpers"
 require "datum/container"
 require "datum/datum"
+require 'minitest/hooks/test'
 
 # Adds the process_scenario method to ActiveSupport::TestCase and includes
 # the Datum module
@@ -21,22 +22,12 @@ require "datum/datum"
 #       assert_not_nil @marge, "process_scenario did not define @marge"
 #     end
 
-binding_classes = [].tap do |klasses|
-  if defined? ActiveSupport::TestCase
-    klasses << ActiveSupport::TestCase
-  end
+class Minitest::Test
+  include Datum
+  include Minitest::Hooks
 
-  if defined? Minitest::Test
-    klasses << Minitest::Test
-  end
-end
-
-binding_classes.each do |binding_class|
-  binding_class.class_eval do
-    include Datum
-    define_method :process_scenario do |scenario_name|
-      __import scenario_name
-    end
+  define_method :process_scenario do |scenario_name|
+    __import scenario_name
   end
 end
 


### PR DESCRIPTION
Add the `Datum::Transactions` module which supplies the `load_scenarios` method.

To use this new module allows scenarios to be loaded once per test file, cutting down on time spent creating database records.  

Changed dependencies to have Minitest and Minitest::Hooks as dependencies and added Rails and DatabaseCleaner as dev dependencies.

The Readme has been updated to support the new additions.
