### PR TITLE
Fixed support for rails 5

### DIFF
--- a/lib/datum/transactions.rb
+++ b/lib/datum/transactions.rb
@@ -10,7 +10,6 @@ module Datum
         class_attribute :datum_transactions
         self.datum_transactions = true
       end
-      klass.use_transactional_fixtures = false
     end
 
     def load_scenarios
@@ -31,9 +30,7 @@ module Datum
       return super unless self.class.datum_transactions
 
       restore_ivars
-      DatabaseCleaner.cleaning do
-        super
-      end
+      super
     end
 
     def record_ivars

--- a/lib/datum/version.rb
+++ b/lib/datum/version.rb
@@ -1,6 +1,6 @@
 module Datum
   # @!visibility private
-  VERSION = "4.3.0"
+  VERSION = "4.3.1"
 end
 
 
@@ -26,3 +26,6 @@ end
 ## Support added for gems.
 ## 4.3.0
 ## Add load_scenarios and both test and test class level transactions
+## 4.3.1
+## Use rails default transactions for test methods. This should make it easier to
+## support multiple rails versions.


### PR DESCRIPTION
Rails changed the transactional_fixtures variable in 5. This breaks datum transactions so I've removed the around transaction and just use Rails' built in transactions. This has been tested on Lexicon and PMT.